### PR TITLE
COMP: Fix checkout of LeapCxx git repository specifying https protocol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ if(${PROJECT_NAME}_SUPERBUILD)
   ExternalProject_add(LeapCxx
     SOURCE_DIR LeapCxx
     BINARY_DIR ${CMAKE_BINARY_DIR}/LeapCxx-build
-    GIT_REPOSITORY git://github.com/Slicer/LeapCxx
+    GIT_REPOSITORY https://github.com/Slicer/LeapCxx
     GIT_TAG c489fd59f82bea4896ff5a2505c365f12f79405e # leapmotion-python-distributions-0.1.0-2018-08-08-bc659293c
     ${_ep_common_arguments}
     CMAKE_CACHE_ARGS


### PR DESCRIPTION
This commit ensures the https protocol is uses to fetch sources for LeapCxx. Change required following the removal of git protocol by GitHub. See details at https://github.blog/2021-09-01-improving-git-protocol-security-github